### PR TITLE
Fix coefficients in Runge-Kutta slope

### DIFF
--- a/docs/differential-equation/runge-kutta-method.md
+++ b/docs/differential-equation/runge-kutta-method.md
@@ -7,7 +7,7 @@ Runge-Kutta 法の導出や数理的な性質については次回に回しま�
 
 $$
 \begin{aligned}
-x(t_1 + h) &= x(t_1) + h \frac{f_1 + f_2 + f_3 + f_4}{6} \\
+x(t_1 + h) &= x(t_1) + h \frac{f_1 + 2 f_2 + 2 f_3 + f_4}{6} \\
 f_1 &= f \left(t_1, x(t_1) \right) \\
 f_2 &= f \left(t_1 + \frac{h}{2}, x(t_1) + \frac{h}{2} f_1 \right) \\
 f_3 &= f \left(t_1 + \frac{h}{2}, x(t_1) + \frac{h}{2} f_2 \right) \\


### PR DESCRIPTION
Currently Runge-Kutta equation is stated as `x(t1 + h) = x(t1) + (f1 + f2 + f3 + f4) / 6`, but right equation is `x(t1 + h) = x(t1) + (f1 + 2 f2 + 2 f3 + f4) / 6`. It means the coefficients in Runge-Kutta slope are missing. This PR fixes it simply.

Thank you.